### PR TITLE
Feature/mock server

### DIFF
--- a/mock/db.json
+++ b/mock/db.json
@@ -1,0 +1,22 @@
+{
+  "todos": [
+    {
+      "id": 1,
+      "isDone": true,
+      "content": "포트폴리오 만들기",
+      "createdAt": 1693054572327
+    },
+    {
+      "id": 2,
+      "isDone": false,
+      "content": "블로그 글 쓰기",
+      "createdAt": 1693054572327
+    },
+    {
+      "id": 3,
+      "isDone": false,
+      "content": "Spring 강의 듣기",
+      "createdAt": 1693054572327
+    }
+  ]
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,60 +1,69 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./App.css";
 import Header from "./component/Header";
 import TodoEditor from "./component/TodoEditor";
 import TodoList from "./component/TodoList";
 
-const mockData = [
-  {
-    id: 1,
-    isDone: false,
-    content: "포트폴리오 만들기",
-    createdAt: new Date().getTime(),
-  },
-  {
-    id: 2,
-    isDone: false,
-    content: "블로그 글 쓰기",
-    createdAt: new Date().getTime(),
-  },
-  {
-    id: 3,
-    isDone: false,
-    content: "Spring 강의 듣기",
-    createdAt: new Date().getTime(),
-  },
-];
-
+// TODO: 상태 코드에 따른 예외처리
 function App() {
-  const [todos, setTodos] = useState(mockData);
+  const [todos, setTodos] = useState([]);
   const idRef = useRef(4);
 
-  const handleOnCreate = (content) => {
-    const newItem = {
+  console.log(todos);
+
+  const fetchData = async () => {
+    const res = await fetch("http://localhost:4000/todos");
+    const jsonData = await res.json();
+    setTodos(jsonData);
+  };
+
+  const handleOnCreate = async (content) => {
+    const newTodo = {
       id: idRef.current,
       isDone: false,
       content,
       createdAt: new Date().getTime(),
     };
-
-    setTodos([...todos, newItem]);
+    // setTodos([...todos, newTodo]);
+    await fetch("http://localhost:4000/todos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newTodo),
+    });
+    await fetchData();
     idRef.current += 1;
   };
 
-  const handleOnChangeCheckbox = (targetId) => {
-    const updatedTodo = todos.map((todo) => {
-      if (todo.id === targetId) {
-        return { ...todo, isDone: !todo.isDone };
-      }
-      return todo;
+  const handleOnChangeCheckbox = async (targetId) => {
+    // const updatedTodo = todos.map((todo) => {
+    //   if (todo.id === targetId) {
+    //     return { ...todo, isDone: !todo.isDone };
+    //   }
+    //   return todo;
+    // });
+    // setTodos(updatedTodo);
+
+    const todoToUpdate = todos.find((todo) => todo.id === targetId);
+    await fetch(`http://localhost:4000/todos/${targetId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ isDone: !todoToUpdate.isDone }),
     });
-    setTodos(updatedTodo);
+    await fetchData();
   };
 
-  const handleOnDelete = (targetId) => {
-    const updatedTodo = todos.filter((todo) => todo.id !== targetId);
-    setTodos(updatedTodo);
+  const handleOnDelete = async (targetId) => {
+    // const updatedTodo = todos.filter((todo) => todo.id !== targetId);
+    // setTodos(updatedTodo);
+    await fetch(`http://localhost:4000/todos/${targetId}`, {
+      method: "DELETE",
+    });
+    await fetchData();
   };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
 
   return (
     <div className="App">


### PR DESCRIPTION
## 이슈 번호 또는 링크
https://github.com/users/dawwson/projects/1/views/1?pane=issue&itemId=36655749
<br>

## 💡 변경 이유
백엔드 연동 전 Mock 서버 연동
<br>

## 🔑 주요 변경사항
- json-server를 전역에 설치 : `npm install -g json-server`
- mock 데이터를 .json 파일로 분리
- todo 조회/생성/수정/삭제 기능을 mock 서버와 연동 => 새로 고침해도 데이터가 유지됨.

### 적용된 Mock 서버 API
<img width="892" alt="image" src="https://github.com/dawwson/todo-app-fe/assets/45624238/306eec87-64c0-4ccd-8820-60ff9337a0a1">

<br>

## 📷 테스트 결과

https://github.com/dawwson/todo-app-fe/assets/45624238/1a523703-ab6e-48ff-bef2-683effe5217f

